### PR TITLE
Feat/exclude bot prs

### DIFF
--- a/update-prs-auto-merge-enabled/script.js
+++ b/update-prs-auto-merge-enabled/script.js
@@ -67,7 +67,6 @@ module.exports = async ({github, context}) => {
     const excludedAuthors = ['renovate[bot]', 'dependabot[bot]'];
 
     const autoMergeEnabledPRs = pullRequestNodes
-        .filter(pr => pr.autoMergeRequest && pr.autoMergeRequest.enabledAt && pr.mergeable !== 'CONFLICTING')
         .filter(pr => {
             const authorLogin = pr.author?.login;
             if (excludedAuthors.includes(authorLogin)) {
@@ -76,6 +75,7 @@ module.exports = async ({github, context}) => {
             }
             return true;
         })
+        .filter(pr => pr.autoMergeRequest && pr.autoMergeRequest.enabledAt && pr.mergeable !== 'CONFLICTING')
         .map(pr => ({id: pr.id, url: pr.url}))
         .slice(0, limit)
     ;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Pull requests authored by certain bot accounts are now excluded from auto-merge updates, ensuring only relevant PRs are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->