### PR TITLE
Revert "script.js の更新"

### DIFF
--- a/update-prs-auto-merge-enabled/script.js
+++ b/update-prs-auto-merge-enabled/script.js
@@ -64,7 +64,7 @@ module.exports = async ({github, context}) => {
     console.log(`Update method: ${updateMethod}`);
 
     // Exclude bot PRs that auto-update themselves to avoid conflicts
-    const excludedAuthors = ['renovate', 'mend',  'dependabot'];
+    const excludedAuthors = ['renovate', 'dependabot'];
 
     const autoMergeEnabledPRs = pullRequestNodes
         .filter(pr => {


### PR DESCRIPTION
Reverts air-hand/common-actions#24

Cancelled that rening github app 
Ref: https://github.com/renovatebot/renovate/discussions/37842

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated auto-merge rules to allow PRs from Mend by removing it from the excluded authors list; Renovate and Dependabot remain excluded.
  - Eligible Mend PRs can now auto-merge under existing safeguards; no other behavior is changed.
  - No impact on UI or user workflows; this adjusts automation for dependency updates only.
  - No configuration changes required for existing setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->